### PR TITLE
Removed unused function failmsgp()

### DIFF
--- a/include/pyboostcvconverter/pyboostcvconverter.hpp
+++ b/include/pyboostcvconverter/pyboostcvconverter.hpp
@@ -41,7 +41,6 @@ catch (const cv::Exception &e) \
 //===================   ERROR HANDLING     =========================================================
 
 static int failmsg(const char *fmt, ...);
-static PyObject* failmsgp(const char *fmt, ...);
 
 //===================   THREADING     ==============================================================
 class PyAllowThreads;

--- a/src/pyboost_cv2_converter.cpp
+++ b/src/pyboost_cv2_converter.cpp
@@ -26,19 +26,6 @@ static int failmsg(const char *fmt, ...)
 	return 0;
 }
 
-static PyObject* failmsgp(const char *fmt, ...)
-		{
-	char str[1000];
-
-	va_list ap;
-	va_start(ap, fmt);
-	vsnprintf(str, sizeof(str), fmt, ap);
-	va_end(ap);
-
-	PyErr_SetString(PyExc_TypeError, str);
-	return 0;
-}
-
 //===================   THREADING     ==============================================================
 
 class PyAllowThreads

--- a/src/pyboost_cv3_converter.cpp
+++ b/src/pyboost_cv3_converter.cpp
@@ -25,19 +25,6 @@ static int failmsg(const char *fmt, ...) {
 	return 0;
 }
 
-static PyObject* failmsgp(const char *fmt, ...)
-		{
-	char str[1000];
-
-	va_list ap;
-	va_start(ap, fmt);
-	vsnprintf(str, sizeof(str), fmt, ap);
-	va_end(ap);
-
-	PyErr_SetString(PyExc_TypeError, str);
-	return 0;
-}
-
 //===================   THREADING     ==============================================================
 class PyAllowThreads {
 public:


### PR DESCRIPTION
Couldn't find any usage of this function in this repository. Also reported by the compiler:

    warning: unused function 'failmsgp' [-Wunused-function]
    static PyObject* failmsgp(const char *fmt, ...)
                     ^